### PR TITLE
Add missing npm run build command, also strip --omit=dev because it's…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
 COPY .npmrc .npmrc
 COPY package.json package.json
 COPY package-lock.json package-lock.json
-RUN npm ci --omit=dev
+RUN npm ci
 COPY . .
+RUN npm run build
 COPY --from=build_healthcheck /app/extra/healthcheck /app/extra/healthcheck
 
 FROM louislam/uptime-kuma:base-debian AS release


### PR DESCRIPTION
- Adds `npm run build` to fix the missing `dist/index.html` error
- Strips away `omit-dev` flag because it was causing missing dependencies issues like missing `Vite`

1. `docker buildx build . --output type=docker --platform linux/amd64 -t kuma:test`
2. `docker run --platform linux/amd64 -p 3001:3001 kuma:test`
